### PR TITLE
ci: fix ci failure(#58)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,12 @@ Pytest setup
 # pylint: disable=missing-function-docstring
 # pylint: disable=redefined-outer-name
 import os
+import pathlib
 import subprocess
 import time
 import uuid
 
+import oss2
 import pytest
 import requests
 
@@ -16,29 +18,38 @@ from ossfs import OSSFileSystem
 PORT = 5555
 AccessKeyId = os.environ.get("OSS_ACCESS_KEY_ID", "")
 AccessKeySecret = os.environ.get("OSS_SECRET_ACCESS_KEY", "")
+LICENSE_PATH = os.path.join(
+    pathlib.Path(__file__).parent.parent.resolve(), "LICENSE"
+)
+NUMBERS = b"1234567890\n"
 
 
 test_id = uuid.uuid4()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def emulator_endpoint():
-    return "http://127.0.0.1:%s/" % PORT
+    return f"http://127.0.0.1:{PORT}/"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def endpoint():
     return os.environ.get("OSS_ENDPOINT")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def test_bucket_name():
     return os.environ.get("OSS_TEST_BUCKET_NAME")
 
 
-@pytest.fixture()
-def test_path(test_bucket_name):
-    return f"/{test_bucket_name}/ossfs_test/{test_id}"
+@pytest.fixture(scope="session")
+def test_directory():
+    return f"ossfs_test/{test_id}"
+
+
+@pytest.fixture(scope="session")
+def test_path(test_bucket_name, test_directory):
+    return f"/{test_bucket_name}/{test_directory}"
 
 
 @pytest.fixture()
@@ -46,7 +57,7 @@ def oss_emulator_server_start(emulator_endpoint):
     """
     Start a local emulator server
     """
-    with subprocess.Popen("ruby bin/emulator -r store -p {}".format(PORT)):
+    with subprocess.Popen(f"ruby bin/emulator -r store -p {PORT}"):
 
         timeout = 5
         while timeout > 0:
@@ -61,7 +72,7 @@ def oss_emulator_server_start(emulator_endpoint):
         yield
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def init_config(endpoint):
     result = {}
     result["key"] = AccessKeyId
@@ -73,3 +84,37 @@ def init_config(endpoint):
 @pytest.fixture()
 def ossfs(init_config):
     return OSSFileSystem(**init_config)
+
+
+def put_object(endpoint, bucket_name, filename, contents):
+    auth = oss2.Auth(AccessKeyId, AccessKeySecret)
+    bucket = oss2.Bucket(auth, endpoint, bucket_name)
+    bucket.put_object(filename, contents)
+
+
+def put_file(endpoint, bucket_name, key, filename):
+    auth = oss2.Auth(AccessKeyId, AccessKeySecret)
+    bucket = oss2.Bucket(auth, endpoint, bucket_name)
+    bucket.put_object_from_file(key, filename)
+
+
+@pytest.fixture(scope="session")
+def file_in_anonymous(endpoint, test_directory):
+    bucket = "dvc-anonymous"
+    file = f"{test_directory}/file"
+    put_object(endpoint, bucket, file, "foobar")
+    return f"/{bucket}/{file}"
+
+
+@pytest.fixture(scope="session")
+def number_file(test_bucket_name, endpoint, test_directory):
+    filename = f"{test_directory}/number"
+    put_object(endpoint, test_bucket_name, filename, NUMBERS)
+    return f"/{test_bucket_name}/{filename}"
+
+
+@pytest.fixture(scope="session")
+def license_file(test_bucket_name, endpoint, test_directory):
+    filename = f"{test_directory}/LICENSE"
+    put_file(endpoint, test_bucket_name, filename, LICENSE_PATH)
+    return f"/{test_bucket_name}/{filename}"

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -73,6 +73,6 @@ def test_env_endpoint(endpoint, test_bucket_name, monkeypatch):
     ossfs.ls(test_bucket_name)
 
 
-def test_anonymous_login():
-    ossfs = OSSFileSystem(endpoint="http://oss-cn-hangzhou.aliyuncs.com")
-    ossfs.cat("/dvc-test-anonymous/LICENSE", connect_timeout=600)
+def test_anonymous_login(file_in_anonymous, endpoint):
+    ossfs = OSSFileSystem(endpoint=endpoint)
+    ossfs.cat(f"{file_in_anonymous}")

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -132,14 +132,13 @@ def test_bulk_delete(ossfs, test_path):
     )
 
 
-def test_ossfs_file_access(ossfs, test_bucket_name):
-    fn = test_bucket_name + "/number"
+def test_ossfs_file_access(ossfs, number_file):
     data = b"1234567890\n"
-    assert ossfs.cat(fn) == data
-    assert ossfs.head(fn, 3) == data[:3]
-    assert ossfs.tail(fn, 3) == data[-3:]
-    assert ossfs.tail(fn, 10000) == data
-    assert ossfs.info(fn)["Size"] == len(data)
+    assert ossfs.cat(number_file) == data
+    assert ossfs.head(number_file, 3) == data[:3]
+    assert ossfs.tail(number_file, 3) == data[-3:]
+    assert ossfs.tail(number_file, 10000) == data
+    assert ossfs.info(number_file)["Size"] == len(data)
 
 
 def test_du(ossfs, test_path):
@@ -173,16 +172,16 @@ def test_ossfs_ls(ossfs, test_path):
     assert all(isinstance(item, dict) for item in L)
 
 
-def test_ossfs_big_ls(ossfs, test_bucket_name):
-    path = test_bucket_name + "/test_ossfs_big_ls"
+def test_ossfs_big_ls(ossfs, test_path):
+    path = test_path + "/test_ossfs_big_ls"
     if not ossfs.exists(path):
         for x in range(1200):
-            ossfs.touch(path + "/%i.part" % x)
+            ossfs.touch(path + f"/{x}.part")
     files = ossfs.find(path, connect_timeout=600)
     for x in range(1200):
-        file = path + "/%i.part" % x
+        file = path + f"/{x}.part"
         if file not in files:
-            ossfs.touch(path + "/%i.part" % x)
+            ossfs.touch(path + f"/{x}.part")
 
     assert len(ossfs.find(path, connect_timeout=600)) == 1200
 
@@ -210,15 +209,13 @@ def test_ossfs_glob(ossfs, test_path):
     assert fn2 not in ossfs.glob(path + "/nested/file.*")
 
 
-def test_copy(ossfs, test_bucket_name, test_path):
-    number_file = test_bucket_name + "/number"
+def test_copy(ossfs, number_file, test_path):
     new_file = test_path + "/test_copy/file"
     ossfs.copy(number_file, new_file)
     assert ossfs.cat(number_file) == ossfs.cat(new_file)
 
 
-def test_move(ossfs, test_bucket_name, test_path):
-    number_file = test_bucket_name + "/number"
+def test_move(ossfs, number_file, test_path):
     from_file = test_path + "/test_move/from"
     to_file = test_path + "/test_move/to"
     ossfs.copy(number_file, from_file)
@@ -378,7 +375,7 @@ def test_get_file_info_with_selector(ossfs, test_path):
         elif info["name"].rstrip("/").endswith(dir_a):
             assert info["type"] == "directory"
         else:
-            raise ValueError("unexpected path {}".format(info["name"]))
+            raise ValueError(f"unexpected path {info['name']}")
 
 
 def test_same_name_but_no_exact(ossfs, test_path):
@@ -419,8 +416,8 @@ def test_leading_forward_slash(ossfs, test_path):
     assert ossfs.exists("/" + path + "/some/file")
 
 
-def test_find_with_prefix(ossfs, test_bucket_name):
-    path = test_bucket_name + "/test_find_with_prefix"
+def test_find_with_prefix(ossfs, test_path):
+    path = test_path + "/test_find_with_prefix"
     if not ossfs.exists(path):
         for cursor in range(100):
             ossfs.touch(path + f"/prefixes/test_{cursor}")
@@ -448,10 +445,10 @@ WRITE_BLOCK_SIZE = 2 ** 13  # 8KB blocks
 READ_BLOCK_SIZE = 2 ** 14  # 16KB blocks
 
 
-def test_get_put_file(ossfs, tmpdir, test_bucket_name):
+def test_get_put_file(ossfs, tmpdir, test_path):
     src_file = str(tmpdir / "source")
     src2_file = str(tmpdir / "source_2")
-    dest_file = test_bucket_name + "/get_put_file/dest"
+    dest_file = test_path + "/get_put_file/dest"
 
     data = b"test" * 2 ** 20
 


### PR DESCRIPTION
fix: #58
Currently some of the tests relied on the test bucket status. Because the test
files were created manually several months ago. We need to decouple
this to make our tests more robust.

Create test files before the tests session begin.