### PR TITLE
implemenmt `info` related methods in `AioOSSFileSystem`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,9 @@ jobs:
         OSS_TEST_STS_ID: ${{ secrets.OSS_TEST_STS_ID}}
         OSS_TEST_STS_KEY: ${{ secrets.OSS_TEST_STS_KEY}}
         OSS_TEST_STS_ARN: ${{ secrets.OSS_TEST_STS_ARN}}
-        OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT}}
-        OSS_TEST_BUCKET_NAME: ${{ secrets.OSS_TEST_BUCKET_NAME}}
-        OSS_TEST_ANONYMOUS_BUCKET_NAME: ${{ secrets.OSS_TEST_ANONYMOUS_BUCKET_NAME}}
+        OSS_ENDPOINT: ${{ vars.OSS_ENDPOINT}}
+        OSS_TEST_BUCKET_NAME: ${{ vars.OSS_TEST_BUCKET_NAME}}
+        OSS_TEST_ANONYMOUS_BUCKET_NAME: ${{ vars.OSS_TEST_ANONYMOUS_BUCKET_NAME}}
       run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml
 
     - name: Upload coverage report

--- a/src/ossfs/async_oss.py
+++ b/src/ossfs/async_oss.py
@@ -73,7 +73,7 @@ class AioOSSFileSystem(BaseOSSFileSystem, AsyncFileSystem):
         """
         get the new aio bucket instance
         """
-        if not self._endpoint:
+        if self._endpoint is None:
             raise ValueError("endpoint is required")
         try:
             return AioBucket(
@@ -123,7 +123,8 @@ class AioOSSFileSystem(BaseOSSFileSystem, AsyncFileSystem):
         timeout: Optional[int] = None,
         **kwargs,
     ):
-        assert self._endpoint
+        if self._endpoint is None:
+            raise ValueError("endpoint is required")
         await self.set_session()
         if bucket:
             service: Union[AioService, AioBucket] = self._get_bucket(bucket, timeout)

--- a/src/ossfs/base.py
+++ b/src/ossfs/base.py
@@ -4,7 +4,7 @@ Code of base class of OSSFileSystem
 import logging
 import os
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from fsspec.spec import AbstractFileSystem
 from fsspec.utils import stringify_path
@@ -185,34 +185,13 @@ class BaseOSSFileSystem(AbstractFileSystem):
         self, bucket: str, obj: "SimplifiedObjectInfo"
     ) -> Dict:
         data: Dict[str, Any] = {
-            "Key": obj.key,
+            "name": "/".join([bucket, obj.key]),
             "type": "file",
-            "Size": obj.size,
-            "StorageClass": "OBJECT",
+            "size": obj.size,
         }
         if obj.last_modified:
             data["LastModified"] = obj.last_modified
         if obj.is_prefix():
             data["type"] = "directory"
-            data["Size"] = 0
-        self._fill_info(data, bucket)
+            data["size"] = 0
         return data
-
-    @staticmethod
-    def _fill_info(file: Dict[str, Any], bucket: Optional[str] = None):
-        file["size"] = file["Size"]
-        if bucket:
-            file["Key"] = "/".join([bucket, file["Key"]])
-        file["name"] = file["Key"]
-
-    def _post_process_ls_result(self, path: str, files: List[Dict[str, Any]]):
-        if path.startswith("/"):
-            for file in files:
-                file["name"] = f'/{file["name"].lstrip("/")}'
-                file["Key"] = f'/{file["Key"].lstrip("/")}'
-        else:
-            for file in files:
-                file["name"] = f'/{file["name"].lstrip("/")}'
-                file["Key"] = f'/{file["Key"].lstrip("/")}'
-
-        return files

--- a/src/ossfs/utils.py
+++ b/src/ossfs/utils.py
@@ -1,0 +1,94 @@
+"""utils of ossfs"""
+import copy
+import inspect
+from functools import wraps
+from typing import Any, Dict, List
+
+
+def _copy_and_pretify_list(
+    path: str, result: List[Dict[str, Any]], detail: bool
+) -> List[Dict[str, Any]]:
+    result_copy = copy.deepcopy(result)
+    if not detail:
+        for path_info in result_copy:
+            if path.startswith("/"):
+                path_info["name"] = f'/{path_info["name"].lstrip("/")}'
+            else:
+                path_info["name"] = f'{path_info["name"].lstrip("/")}'
+        final_results = sorted(info["name"] for info in result_copy)
+    else:
+        for path_info in result_copy:
+            path_info["Size"] = path_info["size"]
+            path_info["Key"] = path_info["name"]
+            if path.startswith("/"):
+                path_info["name"] = f'/{path_info["name"].lstrip("/")}'
+                path_info["Key"] = f'/{path_info["Key"].lstrip("/")}'
+            else:
+                path_info["name"] = f'{path_info["name"].lstrip("/")}'
+                path_info["Key"] = f'{path_info["Key"].lstrip("/")}'
+        final_results = sorted(result_copy, key=lambda i: i["name"])
+    return final_results
+
+
+def _format_unify(path: str, result, detail: bool):
+    if not result:
+        return result
+    if isinstance(result, dict):
+        for _, value in result.items():
+            nested = isinstance(value, dict)
+            break
+        if nested:
+            result_list = [path_info for _, path_info in result.items()]
+            normed_result = _copy_and_pretify_list(path, result_list, detail)
+            if detail:
+                return {path_info["name"]: path_info for path_info in normed_result}
+            return normed_result
+
+        return _copy_and_pretify_list(path, [result], detail)[0]
+
+    return _copy_and_pretify_list(path, result, detail)
+
+
+def pretify_info_result(func):
+    """Make the return values of `ls` and `info` follows the fsspec's standard
+    Examples:
+    --------------------------------
+    @pretify_info_result
+    def ls(path: str, ...)
+    """
+
+    @wraps(func)
+    def wrapper(ossfs, path: str, *args, **kwargs):
+        func_params = inspect.signature(func).parameters
+        if "detail" in func_params:
+            detail = kwargs.get("detail", func_params["detail"].default)
+        else:
+            detail = kwargs.get("detail", True)
+        print(func, detail, func_params)
+
+        result = func(ossfs, path, *args, **kwargs)
+        return _format_unify(path, result, detail)
+
+    return wrapper
+
+
+def async_pretify_info_result(func):
+    """Make the return values of async func `ls` and `info` follows the
+    fsspec's standard
+    Examples:
+    --------------------------------
+    @async_pretify_info_result
+    async def ls(path: str, ...)
+    """
+
+    @wraps(func)
+    async def wrapper(ossfs, path: str, *args, **kwargs):
+        func_params = inspect.signature(func).parameters
+        if "detail" in func_params:
+            detail = kwargs.get("detail", func_params["detail"].default)
+        else:
+            detail = kwargs.get("detail", True)
+        result = await func(ossfs, path, *args, **kwargs)
+        return _format_unify(path, result, detail)
+
+    return wrapper

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -33,3 +33,80 @@ def test_ls_bucket(
         assert "cannot list buckets if not logged in" in caplog.text
     finally:
         ossfs._auth = auth  # pylint:disable=protected-access
+
+
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_bucket_is_dir(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_bucket_name: str,
+    anonymous_bucket_name: str,
+):
+    assert ossfs.isdir("")
+    assert ossfs.isdir("/")
+    assert ossfs.isdir(test_bucket_name)
+    assert not ossfs.isdir("non-exist-bucket")
+    assert ossfs.isdir(f"/{anonymous_bucket_name}")
+
+
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_bucket_is_file(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_bucket_name: str,
+    anonymous_bucket_name: str,
+):
+    assert not ossfs.isfile("")
+    assert not ossfs.isfile("/")
+    assert not ossfs.isfile(test_bucket_name)
+    assert not ossfs.isfile("non-exist-bucket")
+    assert not ossfs.isfile(f"/{anonymous_bucket_name}")
+
+
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_bucket_exists(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_bucket_name: str,
+    anonymous_bucket_name: str,
+):
+    assert ossfs.exists("")
+    assert ossfs.exists("/")
+    assert ossfs.exists(test_bucket_name)
+    assert not ossfs.exists("non-exist-bucket")
+    assert ossfs.exists(f"/{anonymous_bucket_name}")
+
+
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_bucket_info(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_bucket_name: str,
+    anonymous_bucket_name: str,
+):
+    assert ossfs.info("") == {
+        "Key": "",
+        "Size": 0,
+        "type": "directory",
+        "size": 0,
+        "name": "",
+    }
+    assert ossfs.info("/") == {
+        "Key": "/",
+        "Size": 0,
+        "type": "directory",
+        "size": 0,
+        "name": "/",
+    }
+    assert ossfs.info(test_bucket_name) == {
+        "Key": test_bucket_name,
+        "type": "directory",
+        "Size": 0,
+        "size": 0,
+        "name": test_bucket_name,
+    }
+    with pytest.raises(FileNotFoundError):
+        assert ossfs.info("non-exist-bucket")
+    assert ossfs.info(f"/{anonymous_bucket_name}") == {
+        "Key": f"/{anonymous_bucket_name}",
+        "type": "directory",
+        "Size": 0,
+        "size": 0,
+        "name": f"/{anonymous_bucket_name}",
+    }


### PR DESCRIPTION
implemenmt `info` related methods in `AioOSSFileSystem`

fix: #99
1. _info methods  to `AioOSSFileSystem`.
2. Add _isfile, _isdir, _size, _sizes, _exists and _info tests for
   objects.
3. Add _isfile, _isdir, _size, _sizes, _exists and _info tests for
   buckets.
4. Make login tests passed for AioOSSFileSystem