### PR TITLE
Implement `find` related operations in the `AioOSSFileSystem`

### DIFF
--- a/src/ossfs/base.py
+++ b/src/ossfs/base.py
@@ -195,3 +195,17 @@ class BaseOSSFileSystem(AbstractFileSystem):
             data["type"] = "directory"
             data["size"] = 0
         return data
+
+    def _verify_find_arguments(
+        self, path: str, maxdepth: Optional[int], withdirs: bool, prefix: str
+    ) -> str:
+        path = self._strip_protocol(path)
+        bucket, _ = self.split_path(path)
+        if not bucket:
+            raise ValueError("Cannot traverse all of the buckets")
+        if (withdirs or maxdepth) and prefix:
+            raise ValueError(
+                "Can not specify 'prefix' option alongside "
+                "'withdirs'/'maxdepth' options."
+            )
+        return path

--- a/src/ossfs/core.py
+++ b/src/ossfs/core.py
@@ -256,14 +256,9 @@ class OSSFileSystem(BaseOSSFileSystem):  # pylint:disable=too-many-public-method
             when used by glob, but users usually only want files.
         kwargs are passed to ``ls``.
         """
-        path = self._strip_protocol(path)
         out = {}
         prefix = kwargs.pop("prefix", "")
-        if (withdirs or maxdepth) and prefix:
-            raise ValueError(
-                "Can not specify 'prefix' option alongside "
-                "'withdirs'/'maxdepth' options."
-            )
+        path = self._verify_find_arguments(path, maxdepth, withdirs, prefix)
         if prefix:
             connect_timeout = kwargs.get("connect_timeout", None)
             for info in self._ls_dir(

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -197,7 +197,10 @@ def test_ossfs_file_access(ossfs: "OSSFileSystem", number_file: str):
     assert ossfs.info(number_file)["Size"] == len(NUMBERS)
 
 
-def test_du(ossfs: "OSSFileSystem", test_path: str, bucket: "Bucket"):
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_du(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_path: str, bucket: "Bucket"
+):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"
     file1 = path + "file1"
@@ -239,10 +242,13 @@ def test_ossfs_big_ls(
     for num in range(120):
         bucket.put_object(bucket_relative_path(f"{path}{num}.part"), "foo")
 
-    assert len(ossfs.find(path, connect_timeout=600)) == 120
+    assert len(ossfs.ls(path, detail=False, connect_timeout=600)) == 120
 
 
-def test_ossfs_glob(ossfs: "OSSFileSystem", test_path: str, bucket: "Bucket"):
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_ossfs_glob(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_path: str, bucket: "Bucket"
+):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"
     file1 = path + "nested/file.dat"
@@ -432,8 +438,9 @@ def test_modified(
         ossfs.modified(path=test_bucket_name)
 
 
-def test_get_file_info_with_selector(
-    ossfs: "OSSFileSystem", test_path: str, bucket: "Bucket"
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_find_file_info_with_selector(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_path: str, bucket: "Bucket"
 ):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"
@@ -508,7 +515,10 @@ def test_leading_forward_slash(
     assert ossfs.exists("/" + path + "some/file")
 
 
-def test_find_with_prefix(ossfs: "OSSFileSystem", test_path: str, bucket: "Bucket"):
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_find_with_prefix(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_path: str, bucket: "Bucket"
+):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"
     if not ossfs.exists(path):


### PR DESCRIPTION
fix: #101

1. Add async version of `find` methods for the `AioOSSFileSystem`
2. Add async tests for  `du`, `glob` and `find`.