### PR TITLE
Implement cat related operations in the AysncOSSFileSystem

### DIFF
--- a/src/ossfs/core.py
+++ b/src/ossfs/core.py
@@ -19,6 +19,7 @@ from .utils import as_progress_handler, pretify_info_result
 
 if TYPE_CHECKING:
     from oss2.models import (
+        GetObjectResult,
         InitMultipartUploadResult,
         PutObjectResult,
         SimplifiedObjectInfo,
@@ -561,3 +562,15 @@ class OSSFileSystem(BaseOSSFileSystem):  # pylint:disable=too-many-public-method
         if "CreateTime" in result:
             del result["CreateTime"]
         return result
+
+    def cat_file(self, path: str, start: int = None, end: int = None, **kwargs):
+        bucket, object_name = self.split_path(path)
+        object_stream: "GetObjectResult" = self._call_oss(
+            "get_object",
+            bucket=bucket,
+            key=object_name,
+            byte_range=(start, end),
+            **kwargs,
+        )
+
+        return object_stream.read()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -287,9 +287,15 @@ def test_file_status(ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_pat
         assert not f.writable()
 
 
+@pytest.mark.parametrize("ossfs", ["async", "sync"], indirect=True)
 @pytest.mark.parametrize("data_size", [0, 20, 10 * 2**20])
 @pytest.mark.parametrize("append_size", [0, 20, 10 * 2**20])
-def test_append(ossfs, test_path, data_size, append_size):
+def test_append(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_path: str,
+    data_size: int,
+    append_size: int,
+):
     file = test_path + f"/test_append/file_{data_size}_{append_size}"
     data = os.urandom(data_size)
     extra = os.urandom(append_size)

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -201,7 +201,10 @@ def test_bulk_delete(
     assert not bucket.object_exists(bucket_relative_path(nest_file2))
 
 
-def test_ossfs_file_access(ossfs: "OSSFileSystem", number_file: str):
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_ossfs_file_access(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], number_file: str
+):
     assert ossfs.cat(number_file) == NUMBERS
     assert ossfs.head(number_file, 3) == NUMBERS[:3]
     assert ossfs.tail(number_file, 3) == NUMBERS[-3:]
@@ -408,7 +411,10 @@ def test_touch(
     assert bucket.get_object(bucket_relative_path(filename)).read() == b"data"
 
 
-def test_cat_missing(ossfs: "OSSFileSystem", test_path: str, bucket: "Bucket"):
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
+def test_cat_missing(
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"], test_path: str, bucket: "Bucket"
+):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"
     file1 = path + "file0"
@@ -443,8 +449,12 @@ def test_get_directories(
     assert {"key0", "key1"} == set(os.listdir(os.path.join(d, "dirkey")))
 
 
+@pytest.mark.parametrize("ossfs", ["sync", "async"], indirect=True)
 def test_modified(
-    ossfs: "OSSFileSystem", test_path: str, test_bucket_name: str, bucket: "Bucket"
+    ossfs: Union["OSSFileSystem", "AioOSSFileSystem"],
+    test_path: str,
+    test_bucket_name: str,
+    bucket: "Bucket",
 ):
     function_name = inspect.stack()[0][0].f_code.co_name
     path = f"{test_path}/{function_name}/"


### PR DESCRIPTION
fix: #96

1. Add `cat_file` to the `AioOSSFileSystem`
3. Add `modified` to the `AioOSSFileSystem`
2. Make tests passed related to `cat` and `modified`