### PR TITLE
deps: unpin fsspec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir=
     =src
 packages = find:
 install_requires=
-    fsspec==2023.6.0
+    fsspec>=2023.6.0
     oss2==2.18.1
     aiooss2==0.2.7
 


### PR DESCRIPTION
ossfs is quite stable now and works fine with newer fsspec versions, so we can probably just unpin fsspec version similar to adlfs to avoid needing to release ossfs every time there is a newer fsspec version.

Closes https://github.com/fsspec/ossfs/pull/136