### PR TITLE
Update core.py

### DIFF
--- a/src/ossfs/core.py
+++ b/src/ossfs/core.py
@@ -556,7 +556,7 @@ class OSSFileSystem(BaseOSSFileSystem):  # pylint:disable=too-many-public-method
         if norm_path == "":
             result = {"name": path, "size": 0, "type": "directory"}
         else:
-            result = super().info(path, **kwargs)
+            result = super().info(norm_path, **kwargs)
         if "StorageClass" in result:
             del result["StorageClass"]
         if "CreateTime" in result:


### PR DESCRIPTION
在使用duckdb的时候，发现oss://xxx/xxx.xx形式格式，总是找不到文件。调试发现，在调用ossfs的info方法的时候，会进入到fsspec的父类AbstractFileSystem中的info方法中。如果传入原始输入的path，会出现明明获得了文件信息，但是执行[o for o in out if o["name"].rstrip("/") == path]这一行的时候，找不到文件，从而返回错误的文件信息，进而读不到文件。 ossfs的info方法中，已经获得了去除协议头和正斜杠的norm_path，把其传入AbstractFileSystem中的info方法中，可以获得正确的结果